### PR TITLE
add Hierarchical Clustering & some docstring fixes

### DIFF
--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -579,10 +579,6 @@ After calling `predict(mach)`, the fields of `report(mach)`  are:
 using MLJ
 
 X, labels  = make_moons(400, noise=0.09, rng=1) # synthetic data with 2 clusters; X
-y = map(labels) do label
-    label == 0 ? "cookie" : "monster"
-end;
-y = coerce(y, Multiclass);
 
 HierarchicalClustering = @load HierarchicalClustering pkg=Clustering
 model = HierarchicalClustering(linkage = :complete)

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -197,7 +197,7 @@ function (cutter::DendrogramCutter)(; h = nothing, k = 3)
     MMI.categorical(Cl.cutree(cutter.dendrogram, k = k, h = h))
 end
 function Base.show(io::IO, ::DendrogramCutter)
-    println(io, "Dendrogram Cutter.")
+    print(io, "Dendrogram Cutter.")
 end
 
 function MMI.predict(model::HierarchicalClustering, ::Nothing, X)

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -571,7 +571,7 @@ After calling `predict(mach)`, the fields of `report(mach)`  are:
 
 - `dendrogram`: the dendrogram that was computed when calling `predict`.
 
-- `cutter`: a dendrogram cutter that can be called with a height `h` or a number of clusters `k`, to obtain a new assignment of the data points to clusters.
+- `cutter`: a dendrogram cutter that can be called with a height `h` or a number of clusters `k`, to obtain a new assignment of the data points to clusters (see example below).
 
 # Examples
 

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -196,8 +196,8 @@ function MMI.predict(model::HierarchicalClustering, ::Nothing, X)
                                         model.branchorder)
         model._cache = (dendrogram = dendrogram, Xhash = Xhash)
     end
-    y = Cl.cutree(model._cache.dendrogram, k = model.k, h = model.h)
-    return y, model._cache
+    yhat = MMI.categorical(Cl.cutree(model._cache.dendrogram, k = model.k, h = model.h))
+    return yhat, model._cache
 end
 
 MMI.reporting_operations(::Type{<:HierarchicalClustering}) = (:predict,)

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -562,8 +562,7 @@ In MLJ or MLJBase, create a machine with
 
 - `predict(mach, X)`: return cluster label assignments, as an unordered
   `CategoricalVector`. Here `X` is any table of input features (eg, a `DataFrame`) whose
-  columns are of scitype `Continuous`; check column scitypes with `schema(X)`. Note that
-  points of type `noise` will always get a label of `0`.
+  columns are of scitype `Continuous`; check column scitypes with `schema(X)`. 
 
 
 # Report

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -249,9 +249,9 @@ metadata_model(
 
 metadata_model(
     HierarchicalClustering,
-    human_name = "Hierarchical clusterer",
+    human_name = "hierarchical clusterer",
     input = MMI.Table(Continuous),
-    output = MMI.Table(Continuous),
+    target = MMI.AbstractVector{<:Multiclass}
     path = "$(PKG).HierarchicalClustering"
 )
 

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -214,7 +214,7 @@ MMI.reporting_operations(::Type{<:HierarchicalClustering}) = (:predict,)
 # # METADATA
 
 metadata_pkg.(
-    (KMeans, KMedoids, DBSCAN),
+    (KMeans, KMedoids, DBSCAN, HierarchicalClustering),
     name="Clustering",
     uuid="aaaa29a8-35af-508c-8bc3-b662a17a0fe5",
     url="https://github.com/JuliaStats/Clustering.jl",
@@ -251,7 +251,6 @@ metadata_model(
     HierarchicalClustering,
     human_name = "hierarchical clusterer",
     input = MMI.Table(Continuous),
-    target = MMI.AbstractVector{<:Multiclass}
     path = "$(PKG).HierarchicalClustering"
 )
 
@@ -549,20 +548,22 @@ In MLJ or MLJBase, create a machine with
 
 - `linkage = :single`: linkage method (:single, :average, :complete, :ward, :ward_presquared)
 
-- `metrid = SqEuclidean`: metric (see `Distances.jl` for available metrics)
+- `metric = SqEuclidean`: metric (see `Distances.jl` for available metrics)
 
 - `branchorder = :r`: branchorder (:r, :barjoseph, :optimal)
 
 - `h = nothing`: height at which the dendrogram is cut
 
-- `k = 3`: number of clusters; this is ignored, if `h != nothing`.
+- `k = 3`: number of clusters.
+
+If both `k` and `h` are specified, it is guaranteed that the number of clusters is not less than `k` and their height is not above `h`.
 
 
 # Operations
 
 - `predict(mach, X)`: return cluster label assignments, as an unordered
   `CategoricalVector`. Here `X` is any table of input features (eg, a `DataFrame`) whose
-  columns are of scitype `Continuous`; check column scitypes with `schema(X)`. 
+  columns are of scitype `Continuous`; check column scitypes with `schema(X)`.
 
 
 # Report

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,8 +95,25 @@ end
 
 end
 
+# # HierarchicalClustering
+
+@testset "HierarchicalClustering" begin
+    h = Inf; k = 1; linkage = :complete; bo = :optimal;
+    metric = Distances.Euclidean()
+    mach = machine(HierarchicalClustering(h = h, k = k, metric = metric,
+                                          linkage = linkage, branchorder = bo))
+    yhat = predict(mach, X)
+    @test length(union(yhat)) == 1 # uses h = Inf
+    cutter = report(mach).cutter
+    @test length(union(cutter(k = 4))) == 4 # uses k = 4
+    dendro = Clustering.hclust(Distances.pairwise(metric, hcat(X...), dims = 1),
+                               linkage = linkage, branchorder = bo)
+    @test cutter(k = 2) == Clustering.cutree(dendro, k = 2)
+    @test report(mach).dendrogram.heights == dendro.heights
+end
+
 @testset "MLJ interface" begin
-    models = [KMeans, KMedoids, DBSCAN]
+    models = [KMeans, KMedoids, DBSCAN, HierarchicalClustering]
     failures, summary = MLJTestIntegration.test(
         models,
         X;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,3 +50,15 @@ end
     p = predict(barekm, fitresult, X)
     @test all(report.assignments .== p)
 end
+
+####
+#### HierarchicalClustering
+####
+
+@testset "HierarchicalClustering" begin
+    barehc = HierarchicalClustering(linkage = :complete)
+    fitresult, cache, report = fit(barehc, 1, X)
+    barehc.k = 2
+    p = predict(barehc, fitresult, X)
+    @test mean(int(y) .== p) > .5 # that's a somewhat silly test...
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,8 +57,6 @@ end
 
 @testset "HierarchicalClustering" begin
     barehc = HierarchicalClustering(linkage = :complete)
-    fitresult, cache, report = fit(barehc, 1, X)
-    barehc.k = 2
-    p = predict(barehc, fitresult, X)
-    @test mean(int(y) .== p) > .5 # that's a somewhat silly test...
+    hc = transform(barehc, X)
+    @test mean(int(y) .== hc(k = 2)) > .5 # that's a somewhat silly test...
 end


### PR DESCRIPTION
@ablaom `predict(mach, Xnew)` doesn't make any sense for hierarchical clustering, but `predict(mach)` does. Do you think this is still useful like this?

(ps. Sorry for mixing in docstring fixes...)