### PR TITLE
Fix input_scitypes for static models

### DIFF
--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -240,14 +240,14 @@ metadata_model(
     DBSCAN,
     human_name = "DBSCAN clusterer (density-based spatial clustering of "*
     "applications with noise)",
-    input = MMI.Table(Continuous),
+    input_scitype = Tuple{MMI.Table(Continuous)},
     path = "$(PKG).DBSCAN"
 )
 
 metadata_model(
     HierarchicalClustering,
     human_name = "hierarchical clusterer",
-    input = MMI.Table(Continuous),
+    input_scitype = Tuple{MMI.Table(Continuous)},
     path = "$(PKG).HierarchicalClustering"
 )
 


### PR DESCRIPTION
The meaning of `input_scitype` for `Static` models was previously unclear in the MLJ spec, a fact this is corrected [here](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Static-models-(models-that-do-not-generalize)). With this now clarified, the implementation for `DBSCAN` and `HierarchicalClustering` are not compliant and this PR fixes that.