### PR TITLE
Fix input_scitype for AffinityPropagation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJClusteringInterface"
 uuid = "d354fa79-ed1c-40d4-88ef-b8c7bd1568af"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Thibaut Lienart <thibaut.lienart@gmail.com>", "Okon Samuel <okonsamuel50@gmail.com>"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/src/MLJClusteringInterface.jl
+++ b/src/MLJClusteringInterface.jl
@@ -311,7 +311,7 @@ metadata_model(
 metadata_model(
     AffinityPropagation,
     human_name = "Affinity Propagation clusterer",
-    input_scitype = MMI.Table(Continuous),
+    input_scitype = Tuple{MMI.Table(Continuous)},
     path = "$(PKG).AffinityPropagation"
 )
 


### PR DESCRIPTION
`input_scitype` works a bit differently for `Static` models; see https://juliaai.github.io/MLJModelInterface.jl/dev/static_models/#Static-models

This patch fixes the trait for Affinity Propagation. 

The problem is causing integration tests to fail at MLJ.